### PR TITLE
Add workflow step to delete old releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           tag: ${{ env.TAG_NAME }}
           
       - name: Remove old Releases
-        uses: dev-drprasad/delete-older-releases@master
+        uses: dev-drprasad/delete-older-releases@main
         with:
           keep_latest: 3
           delete_tags: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           tag: ${{ env.TAG_NAME }}
           
       - name: Remove old Releases
-        uses: dev-drprasad/delete-older-releases@main
+        uses: dev-drprasad/delete-older-releases@v0.3.4
         with:
           keep_latest: 3
           delete_tags: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,3 +111,11 @@ jobs:
           file_glob: true
           file: ./publish/*
           tag: ${{ env.TAG_NAME }}
+          
+      - name: Remove old Releases
+        uses: dev-drprasad/delete-older-releases@master
+        with:
+          keep_latest: 3
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a step to the CI build workflow that removes older GitHub Releases and associated tags using dev-drprasad/delete-older-releases@master. It keeps the latest 3 releases, deletes tags for removed releases, and uses the repository GITHUB_TOKEN (secrets.GITHUB_TOKEN) to perform the cleanup. This helps keep release history manageable and frees up repository release resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了自动清理旧发布的工作流程动作引用（切换为 main 分支的最新动作），保留最近 3 个发布并清除标签，工作流仍使用现有环境令牌以保持授权和一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->