### PR TITLE
Improve ASN fetch with retries and JSON checks

### DIFF
--- a/asn.sh
+++ b/asn.sh
@@ -46,7 +46,7 @@ while IFS= read -r line; do
     continue
   fi
 
-  jq --raw-output '.data.prefixes.v4.originating[]?' "${response}" >>"${file}"
-  jq --raw-output '.data.prefixes.v6.originating[]?' "${response}" >>"${file}"
+  jq --raw-output '.data.prefixes.v4.originating[]?' "${response}" | sort -u >>"${file}"
+  jq --raw-output '.data.prefixes.v6.originating[]?' "${response}" | sort -u >>"${file}"
 done
 done <${input}

--- a/asn.sh
+++ b/asn.sh
@@ -11,13 +11,42 @@ while IFS= read -r line; do
   echo "==================================="
   echo "Generating ${filename} CIDR list..."
   rm -rf ${file} && touch ${file}
+  # for asn in ${asns[@]}; do
+  #   url="https://stat.ripe.net/data/ris-prefixes/data.json?list_prefixes=true&types=o&resource=${asn}"
+  #   echo "-----------------------"
+  #   echo "Fetching ${asn}..."
+  #   curl -sL ${url} -o ./tmp/${filename}-${asn}.txt \
+  #     -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
+  #   jq --raw-output '.data.prefixes.v4.originating[]' ./tmp/${filename}-${asn}.txt | sort -u >>${file}
+  #   jq --raw-output '.data.prefixes.v6.originating[]' ./tmp/${filename}-${asn}.txt | sort -u >>${file}
+  # done
   for asn in ${asns[@]}; do
-    url="https://stat.ripe.net/data/ris-prefixes/data.json?list_prefixes=true&types=o&resource=${asn}"
-    echo "-----------------------"
-    echo "Fetching ${asn}..."
-    curl -sL ${url} -o ./tmp/${filename}-${asn}.txt \
-      -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
-    jq --raw-output '.data.prefixes.v4.originating[]' ./tmp/${filename}-${asn}.txt | sort -u >>${file}
-    jq --raw-output '.data.prefixes.v6.originating[]' ./tmp/${filename}-${asn}.txt | sort -u >>${file}
-  done
+  url="https://stat.ripe.net/data/ris-prefixes/data.json?list_prefixes=true&types=o&resource=${asn}"
+  response="./tmp/${filename}-${asn}.txt"
+
+  echo "-----------------------"
+  echo "Fetching ${asn}..."
+
+  if ! curl -sL \
+    --connect-timeout 5 \
+    --max-time 20 \
+    --retry 3 \
+    --retry-delay 2 \
+    --retry-connrefused \
+    --fail \
+    -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36' \
+    "${url}" \
+    -o "${response}"; then
+      echo "Request failed or timed out for ${asn}, skipping..."
+      continue
+  fi
+
+  if ! jq empty "${response}" 2>/dev/null; then
+    echo "Invalid JSON returned for ${asn}, skipping..."
+    continue
+  fi
+
+  jq --raw-output '.data.prefixes.v4.originating[]?' "${response}" >>"${file}"
+  jq --raw-output '.data.prefixes.v6.originating[]?' "${response}" >>"${file}"
+done
 done <${input}

--- a/asn.sh
+++ b/asn.sh
@@ -20,7 +20,7 @@ while IFS= read -r line; do
   #   jq --raw-output '.data.prefixes.v4.originating[]' ./tmp/${filename}-${asn}.txt | sort -u >>${file}
   #   jq --raw-output '.data.prefixes.v6.originating[]' ./tmp/${filename}-${asn}.txt | sort -u >>${file}
   # done
-  for asn in ${asns[@]}; do
+  for asn in "${asns[@]}"; do
   url="https://stat.ripe.net/data/ris-prefixes/data.json?list_prefixes=true&types=o&resource=${asn}"
   response="./tmp/${filename}-${asn}.txt"
 


### PR DESCRIPTION
Make RIPE fetches more robust by adding curl timeouts, retries, --fail and --retry-connrefused, and saving responses to a tmp file. Validate responses with jq (skip if invalid JSON), use safe jq queries (.[]? ) to avoid errors, and print informative messages when requests fail or time out. This prevents hangs and crashes when remote requests or returned data are problematic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 增强了ASN数据获取的稳定性，引入了超时、重试和失败处理机制
- 改进了响应验证流程，增加了错误日志记录，提高了系统可靠性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->